### PR TITLE
fix(ios): update iOS App Store link to use updated format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cordova-plugin-market
 Cordova (PhoneGap) 3.0+ plugin to open an application on Google Play or iTunes.
 This plugin is compatible only with Android and iOS.
 
-#Instalation
+#Installation
 
 This plugin follows the Cordova 3.0 plugin spec, so it can be installed through the Cordova CLI in your existing Cordova project:
 
@@ -22,7 +22,7 @@ When you want to open the device's store do this:
 
     `cordova.plugins.market.open('yourappname')`
 
-This will open the link `itms-apps://itunes.com/apps/yourappname`
+This will open the link `itms-apps://itunes.com/app/yourappname`
 
 You can also add a success and failure callback like this:
     

--- a/src/ios/CDVMarket.m
+++ b/src/ios/CDVMarket.m
@@ -20,7 +20,7 @@
         
         CDVPluginResult *pluginResult;
         if (appId) {
-            NSString *url = [NSString stringWithFormat:@"itms-apps://itunes.com/apps/%@", appId];
+            NSString *url = [NSString stringWithFormat:@"itms-apps://itunes.com/app/%@", appId];
             [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
             
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
Couldn't get this plugin to work in iOS until I stumbled across this SO post: http://stackoverflow.com/a/3326564/824966

Sure enough, changing `/apps/` to `/app/` did the trick!