### PR TITLE
fix(ios): fix broken iOS market links by using itunes.apple.com instead of itunes.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ When you want to open the device's store do this:
 
     `cordova.plugins.market.open('yourappname')`
 
-This will open the link `itms-apps://itunes.com/app/yourappname`
+This will open the link `itms-apps://itunes.apple.com/app/yourappname`
 
 You can also add a success and failure callback like this:
     

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="com.xmartlabs.cordova.market" version="1.0">
+        id="com.xmartlabs.cordova.market" version="1.1">
     <name>Market</name>
     <description>Cordova Plugin for access to Google Play and Apple Store within your app</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVMarket.m
+++ b/src/ios/CDVMarket.m
@@ -20,7 +20,7 @@
         
         CDVPluginResult *pluginResult;
         if (appId) {
-            NSString *url = [NSString stringWithFormat:@"itms-apps://itunes.com/app/%@", appId];
+            NSString *url = [NSString stringWithFormat:@"itms-apps://itunes.apple.com/app/%@", appId];
             [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
             
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];


### PR DESCRIPTION
Looks like this recently broke and the `itms-apps` links now require using **itunes.apple.com** as the fully qualified domain. Wish Apple would just pick one and stick with it.

Fixes #5 